### PR TITLE
Fix Shadowing playback audio quality

### DIFF
--- a/src/components/ShadowingPlayer.tsx
+++ b/src/components/ShadowingPlayer.tsx
@@ -203,6 +203,11 @@ export default function ShadowingPlayer({ geminiApiKey, geminiModel }: { geminiA
     setPlaybackRate(rate);
     if (audioRef.current) {
       audioRef.current.playbackRate = rate;
+      audioRef.current.preservesPitch = false;
+      // @ts-expect-error Vendor prefix for Firefox
+      audioRef.current.mozPreservesPitch = false;
+      // @ts-expect-error Vendor prefix for Safari
+      audioRef.current.webkitPreservesPitch = false;
     }
   };
 


### PR DESCRIPTION
Disable `preservesPitch` on the audio element when the playback rate changes. When using the shadowing feature and slowing down the playback, preserving pitch uses a time-stretching algorithm that results in a metallic, robotic sound. By setting `preservesPitch = false` (and its vendor prefixes), we avoid this time-stretching and improve perceived audio quality, though pitch will be shifted.

---
*PR created automatically by Jules for task [8203736959354650735](https://jules.google.com/task/8203736959354650735) started by @yuunaka1*