### PR TITLE
Bump patch version and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.15.2] - 2026-05-22
+### Fixed
+- **Shadowing**: Fix Shadowing playback audio quality.
+
 ## [1.15.1] - 2026-05-09
 ### Fixed
 - **UI/UX**: Improved vertical spacing and layout of Markdown content (Help pages and session feedback), specifically increasing margins for `H2`, `H3`, lists, and horizontal rules (`hr`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yuknow",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yuknow",
-      "version": "1.15.1",
+      "version": "1.15.2",
       "license": "MIT",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yuknow",
   "private": true,
-  "version": "1.15.1",
+  "version": "1.15.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Bumps the patch version of the application from 1.15.1 to 1.15.2 using `npm version patch` and updates `CHANGELOG.md` with the latest fix.

---
*PR created automatically by Jules for task [17616423449767013862](https://jules.google.com/task/17616423449767013862) started by @yuunaka1*