### PR TITLE
🎨 Palette: Add missing aria-labels to icon-only buttons

### DIFF
--- a/src/components/GoTanakaKei.tsx
+++ b/src/components/GoTanakaKei.tsx
@@ -157,6 +157,7 @@ export default function GoTanakaKei({ geminiApiKey, geminiModel, geminiVoice }: 
                 onClick={(e) => handleDeleteCustom(e, topic.id)}
                 style={{ position: 'absolute', top: '0.5rem', right: '0.5rem', background: 'none', border: 'none', color: '#ff3333', cursor: 'pointer', opacity: 0.5 }}
                 title="Delete Custom Topic"
+                aria-label="Delete Custom Topic"
               >
                 <Trash2 size={16} />
               </button>

--- a/src/components/PhotoDescription.tsx
+++ b/src/components/PhotoDescription.tsx
@@ -256,7 +256,7 @@ export default function PhotoDescription({ geminiApiKey, geminiModel }: { gemini
                 <button className="btn btn-primary" onClick={startPrep} disabled={isGeneratingImage || !currentPhoto.url} style={{ padding: '0.75rem 2rem' }}>
                   <Play size={18} /> START PRACTICE
                 </button>
-                <button className="btn btn-secondary" onClick={generateNewPhoto} disabled={isGeneratingImage} title="Generate Another Photo">
+                <button className="btn btn-secondary" onClick={generateNewPhoto} disabled={isGeneratingImage} title="Generate Another Photo" aria-label="Generate Another Photo">
                   <RefreshCcw size={18} className={isGeneratingImage ? "animate-spin" : ""} />
                 </button>
               </>

--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -101,6 +101,7 @@ export default function Quiz({ onComplete }: { onComplete: () => void }) {
               style={{ padding: '0.5rem', borderRadius: '50%', background: 'transparent', border: 'none', cursor: 'pointer' }}
               onClick={() => speak(currentCard.vocab.term)}
               title="Listen pronunciation"
+              aria-label="Listen pronunciation"
             >
               <Volume2 size={24} color="var(--brand-primary)" />
             </button>
@@ -121,6 +122,7 @@ export default function Quiz({ onComplete }: { onComplete: () => void }) {
                        style={{ padding: '0.4rem', borderRadius: '50%', background: 'transparent', border: 'none', cursor: 'pointer' }}
                        onClick={() => speak(currentCard.vocab.exampleSentence)}
                        title="Listen example sentence"
+                       aria-label="Listen example sentence"
                      >
                        <Volume2 size={18} color="var(--text-secondary)" />
                      </button>


### PR DESCRIPTION
💡 What: Added missing `aria-label` attributes to icon-only buttons in `Quiz`, `GoTanakaKei`, and `PhotoDescription` components.
🎯 Why: To improve accessibility for screen readers. While these buttons had `title` attributes for tooltips, `title` is not reliably read by all screen readers. Providing an explicit `aria-label` ensures the purpose of the button is clearly communicated.
♿ Accessibility: Improved screen reader support for key interactive elements like playing pronunciation audio, generating new photos, and deleting custom topics.

---
*PR created automatically by Jules for task [159093760657233360](https://jules.google.com/task/159093760657233360) started by @yuunaka1*