### PR TITLE
Fix iOS audio file selection (mp3, m4a, etc.)

### DIFF
--- a/src/components/Coaching.tsx
+++ b/src/components/Coaching.tsx
@@ -82,7 +82,7 @@ export default function Coaching({ geminiApiKey, geminiModel }: { geminiApiKey?:
             SELECT AUDIO
             <input 
               type="file" 
-              accept="audio/*" 
+              accept="audio/*, audio/mp3, audio/mpeg, audio/mp4, audio/wav, audio/x-m4a, .mp3, .m4a, .wav"
               onChange={handleFileChange} 
               style={{ display: 'none' }} 
             />

--- a/src/components/ShadowingPlayer.tsx
+++ b/src/components/ShadowingPlayer.tsx
@@ -379,7 +379,7 @@ export default function ShadowingPlayer({ geminiApiKey, geminiModel }: { geminiA
           <Upload size={18} /> Load Audio File
           <input 
             type="file" 
-            accept="audio/*" 
+            accept="audio/*, audio/mp3, audio/mpeg, audio/mp4, audio/wav, audio/x-m4a, .mp3, .m4a, .wav"
             onChange={handleFileChange} 
             style={{ display: 'none' }} 
           />


### PR DESCRIPTION
Modified `<input type="file" accept="audio/*">` in `ShadowingPlayer.tsx` and `Coaching.tsx` to include specific audio file extensions and MIME types (`audio/*, audio/mp3, audio/mpeg, audio/mp4, audio/wav, audio/x-m4a, .mp3, .m4a, .wav`). This ensures that mp3 and other audio files can be selected on iOS devices, where `audio/*` alone often results in grayed-out files.

---
*PR created automatically by Jules for task [6175947343379620399](https://jules.google.com/task/6175947343379620399) started by @yuunaka1*