### PR TITLE
🧹 Improve code health by properly typing webkitAudioContext

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,4 @@
+interface Window {
+  webkitAudioContext: typeof AudioContext;
+  webkitOfflineAudioContext: typeof OfflineAudioContext;
+}

--- a/src/utils/audioEncoder.ts
+++ b/src/utils/audioEncoder.ts
@@ -2,7 +2,6 @@
 
 export async function sliceAudioFileToWav(file: File, startTime: number, endTime: number): Promise<Blob> {
   const arrayBuffer = await file.arrayBuffer();
-  // @ts-ignore
   const AudioContext = window.AudioContext || window.webkitAudioContext;
   const audioContext = new AudioContext();
   const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
@@ -17,7 +16,6 @@ export async function sliceAudioFileToWav(file: File, startTime: number, endTime
     throw new Error("Invalid time range for audio slicing");
   }
 
-  // @ts-ignore
   const OfflineAudioContext = window.OfflineAudioContext || window.webkitOfflineAudioContext;
   const offlineContext = new OfflineAudioContext(
     audioBuffer.numberOfChannels,

--- a/src/utils/audioUtils.ts
+++ b/src/utils/audioUtils.ts
@@ -4,7 +4,7 @@ export class AudioStreamPlayer {
   nextStartTime: number;
 
   constructor() {
-    this.audioContext = new (window.AudioContext || (window as any).webkitAudioContext)();
+    this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
     this.nextStartTime = this.audioContext.currentTime;
   }
 
@@ -42,7 +42,7 @@ export class AudioStreamPlayer {
 
   stop() {
     this.audioContext.close();
-    this.audioContext = new (window.AudioContext || (window as any).webkitAudioContext)();
+    this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
     this.nextStartTime = this.audioContext.currentTime;
   }
 }
@@ -57,7 +57,7 @@ export class AudioRecorder {
 
   async start(onPcmChunk: (base64: string) => void) {
     this.stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-    this.audioContext = new (window.AudioContext || (window as any).webkitAudioContext)({ sampleRate: 16000 });
+    this.audioContext = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: 16000 });
     this.mediaStreamSrc = this.audioContext.createMediaStreamSource(this.stream);
     
     // ScriptProcessor is deprecated but works uniformly across browsers for raw PCM capture


### PR DESCRIPTION
🎯 **What:** The `@ts-ignore` usage for `OfflineAudioContext` (and `AudioContext`) in `src/utils/audioEncoder.ts` has been removed. A global type augmentation was added to `src/global.d.ts` to properly define `webkitAudioContext` and `webkitOfflineAudioContext` on the `Window` interface.
💡 **Why:** This improves maintainability and code readability by providing proper typings for vendor-prefixed properties in the DOM, avoiding unsafe type overrides like `@ts-ignore` or casting using `(window as any)`.
✅ **Verification:** Verified by compiling the app successfully with `npm run build` and checking the type validation with `npm run lint`.
✨ **Result:** A cleaner codebase where `window.webkitOfflineAudioContext` and `window.webkitAudioContext` are fully typed, bringing type safety to previously ignored sections of `audioEncoder.ts` and `audioUtils.ts`.

---
*PR created automatically by Jules for task [1882204540534170702](https://jules.google.com/task/1882204540534170702) started by @yuunaka1*